### PR TITLE
feat(workflow_engine): Add in hook for producing occurrences from the…

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -4,17 +4,12 @@ from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.processors.detector import DetectorEvaluationResult, DetectorHandler
+from sentry.workflow_engine.processors.detector import StatefulDetectorHandler
 
 
 # TODO: This will be a stateful detector when we build that abstraction
-class MetricAlertDetectorHandler(DetectorHandler[QuerySubscriptionUpdate]):
-    def evaluate(
-        self, data_packet: DataPacket[QuerySubscriptionUpdate]
-    ) -> list[DetectorEvaluationResult]:
-        # TODO: Implement
-        return []
+class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate]):
+    pass
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import logging
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,7 @@ from django.db.models import UniqueConstraint
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
 from sentry.issues import grouptype
+from sentry.issues.grouptype import GroupType
 from sentry.models.owner_base import OwnerModel
 
 if TYPE_CHECKING:
@@ -54,8 +56,12 @@ class Detector(DefaultFieldsModel, OwnerModel):
         return 1
 
     @property
+    def group_type(self) -> builtins.type[GroupType] | None:
+        return grouptype.registry.get_by_slug(self.type)
+
+    @property
     def detector_handler(self) -> DetectorHandler | None:
-        group_type = grouptype.registry.get_by_slug(self.type)
+        group_type = self.group_type
         if not group_type:
             logger.error(
                 "No registered grouptype for detector",


### PR DESCRIPTION
… stateful detector (#80168)

This adds a hook that can be implemented to produce an occurrence specific to the detector that is subclassing the StatefulDetector.

Also change the signature of evaluate to return a dict keyed by groupkey instead of a list. This helps avoid the chance of duplicate results for the same group key.

<!-- Describe your PR here. -->

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
