### PR TITLE
fix(ecosystem): Breaks issue sync cycles (#77754)

### DIFF
--- a/src/sentry/integrations/services/assignment_source.py
+++ b/src/sentry/integrations/services/assignment_source.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from sentry.integrations.models import Integration
+    from sentry.integrations.services.integration import RpcIntegration
+
+
+@dataclass(frozen=True)
+class AssignmentSource:
+    source_name: str
+    integration_id: int
+    queued: datetime = timezone.now()
+
+    @classmethod
+    def from_integration(cls, integration: Integration | RpcIntegration) -> AssignmentSource:
+        return AssignmentSource(
+            source_name=integration.name,
+            integration_id=integration.id,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, input_dict: dict[str, Any]) -> AssignmentSource | None:
+        try:
+            return cls(**input_dict)
+        except (ValueError, TypeError):
+            return None

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from sentry import features
+from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.tasks.sync_assignee_outbound import sync_assignee_outbound
 from sentry.models.group import Group
@@ -92,7 +93,11 @@ def sync_group_assignee_inbound(
 
     if not assign:
         for group in affected_groups:
-            GroupAssignee.objects.deassign(group)
+            GroupAssignee.objects.deassign(
+                group,
+                assignment_source=AssignmentSource.from_integration(integration),
+            )
+
         return affected_groups
 
     users = user_service.get_many_by_email(emails=[email], is_verified=True)
@@ -104,14 +109,23 @@ def sync_group_assignee_inbound(
         user_id = get_user_id(projects_by_user, group)
         user = users_by_id.get(user_id)
         if user:
-            GroupAssignee.objects.assign(group, user)
+            GroupAssignee.objects.assign(
+                group,
+                user,
+                assignment_source=AssignmentSource.from_integration(integration),
+            )
             groups_assigned.append(group)
         else:
             logger.info("assignee-not-found-inbound", extra=log_context)
     return groups_assigned
 
 
-def sync_group_assignee_outbound(group: Group, user_id: int | None, assign: bool = True) -> None:
+def sync_group_assignee_outbound(
+    group: Group,
+    user_id: int | None,
+    assign: bool = True,
+    assignment_source: AssignmentSource | None = None,
+) -> None:
     from sentry.models.grouplink import GroupLink
 
     external_issue_ids = GroupLink.objects.filter(
@@ -120,5 +134,12 @@ def sync_group_assignee_outbound(group: Group, user_id: int | None, assign: bool
 
     for external_issue_id in external_issue_ids:
         sync_assignee_outbound.apply_async(
-            kwargs={"external_issue_id": external_issue_id, "user_id": user_id, "assign": assign}
+            kwargs={
+                "external_issue_id": external_issue_id,
+                "user_id": user_id,
+                "assign": assign,
+                "assignment_source_dict": assignment_source.to_dict()
+                if assignment_source
+                else None,
+            }
         )

--- a/tests/sentry/integrations/services/test_assignment_source.py
+++ b/tests/sentry/integrations/services/test_assignment_source.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from sentry.integrations.services.assignment_source import AssignmentSource
+from sentry.testutils.cases import TestCase
+
+
+class TestAssignmentSource(TestCase):
+    def test_from_dict_empty_array(self):
+        data: dict[str, Any] = {}
+        result = AssignmentSource.from_dict(data)
+        assert result is None
+
+    def test_from_dict_inalid_data(self):
+        data = {
+            "foo": "bar",
+        }
+
+        result = AssignmentSource.from_dict(data)
+        assert result is None
+
+    def test_from_dict_valid_data(self):
+        data = {"source_name": "foo-source", "integration_id": 123}
+
+        result = AssignmentSource.from_dict(data)
+        assert result is not None
+        assert result.source_name == "foo-source"
+        assert result.integration_id == 123
+
+    def test_to_dict(self):
+        source = AssignmentSource(
+            source_name="foo-source",
+            integration_id=123,
+        )
+
+        result = source.to_dict()
+        assert result.get("queued") is not None
+        assert result.get("source_name") == "foo-source"
+        assert result.get("integration_id") == 123

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.utils import sync_group_assignee_inbound
 from sentry.models.activity import Activity
 from sentry.models.groupassignee import GroupAssignee
@@ -148,11 +149,76 @@ class GroupAssigneeTestCase(TestCase):
 
         with self.feature({"organizations:integrations-issue-sync": True}):
             with self.tasks():
-                GroupAssignee.objects.assign(self.group, self.user)
+                GroupAssignee.objects.assign(
+                    self.group,
+                    self.user,
+                )
 
                 mock_sync_assignee_outbound.assert_called_with(
-                    external_issue, user_service.get_user(self.user.id), assign=True
+                    external_issue,
+                    user_service.get_user(self.user.id),
+                    assign=True,
+                    assignment_source=None,
                 )
+
+                assert GroupAssignee.objects.filter(
+                    project=self.group.project,
+                    group=self.group,
+                    user_id=self.user.id,
+                    team__isnull=True,
+                ).exists()
+
+                activity = Activity.objects.get(
+                    project=self.group.project, group=self.group, type=ActivityType.ASSIGNED.value
+                )
+
+                assert activity.data["assignee"] == str(self.user.id)
+                assert activity.data["assigneeEmail"] == self.user.email
+                assert activity.data["assigneeType"] == "user"
+
+    @mock.patch.object(ExampleIntegration, "sync_assignee_outbound")
+    def test_assignee_sync_outbound_assign_with_matching_source_integration(
+        self, mock_sync_assignee_outbound
+    ):
+        group = self.group
+        integration = self.create_integration(
+            organization=group.organization,
+            external_id="123456",
+            provider="example",
+            oi_params={
+                "config": {
+                    "sync_comments": True,
+                    "sync_status_outbound": True,
+                    "sync_status_inbound": True,
+                    "sync_assignee_outbound": True,
+                    "sync_assignee_inbound": True,
+                }
+            },
+        )
+
+        external_issue = ExternalIssue.objects.create(
+            organization_id=group.organization.id, integration_id=integration.id, key="APP-123"
+        )
+
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+        )
+
+        with self.feature({"organizations:integrations-issue-sync": True}):
+            with self.tasks():
+                # Assert that we don't perform an outbound assignment if
+                # the source of the assignment is the same target integration
+                GroupAssignee.objects.assign(
+                    self.group,
+                    self.user,
+                    assignment_source=AssignmentSource.from_integration(integration),
+                )
+
+                mock_sync_assignee_outbound.assert_not_called()
 
                 assert GroupAssignee.objects.filter(
                     project=self.group.project,
@@ -205,7 +271,9 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature({"organizations:integrations-issue-sync": True}):
             with self.tasks():
                 GroupAssignee.objects.deassign(self.group)
-                mock_sync_assignee_outbound.assert_called_with(external_issue, None, assign=False)
+                mock_sync_assignee_outbound.assert_called_with(
+                    external_issue, None, assign=False, assignment_source=None
+                )
 
                 assert not GroupAssignee.objects.filter(
                     project=self.group.project,


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.


---

<!-- kody-pr-summary:start -->
This pull request addresses and fixes integration sync-cycles, particularly for issue assignment and status synchronization.

The core changes include:
*   **Introduced `AssignmentSource`**: A new dataclass, `AssignmentSource`, has been added to track the origin of an assignment or status change, including the integration that initiated it.
*   **Propagated `AssignmentSource`**: The `AssignmentSource` is now passed through the issue synchronization workflow, from Sentry's internal `GroupAssignee` methods to outbound sync tasks (`sync_group_assignee_outbound`, `sync_assignee_outbound`).
*   **Prevented Outbound Sync Cycles**: The `should_sync` logic for integrations has been enhanced. It now checks if an outbound sync for an attribute (like assignee or status) is being triggered by a change that originated from the *same* integration. If the source of the change matches the target integration, the outbound sync is prevented for that specific attribute, effectively breaking potential sync-cycles.

This ensures that if an integration updates an issue in Sentry, Sentry will not attempt to sync that identical change back to the originating integration, thereby preventing infinite loops or redundant updates. Changes originating from Sentry or other integrations will still propagate as expected.
<!-- kody-pr-summary:end -->