### PR TITLE
ref: fix test pollution integrity errors due to cache leaks between t…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import MutableMapping
 import psutil
 import pytest
 import responses
+from django.core.cache import cache
 from django.db import connections
 
 from sentry.silo.base import SiloMode
@@ -102,6 +103,12 @@ def audit_hybrid_cloud_writes_and_deletes(request):
             conn.force_debug_cursor = debug_cursor_state[conn.alias]
 
             validate_protected_queries(conn.queries)
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    yield
+    cache.clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes test pollution issues by ensuring the Django cache is cleared after every test. This prevents cache leaks between tests, which can lead to integrity errors and unreliable test results.
<!-- kody-pr-summary:end -->